### PR TITLE
Update license from MIT and GPL license to MIT license.

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,9 +55,6 @@ Related information
 
 License
 ----------------------------------------------------------------------
-Copyright (c) 2012-2018 miraoto
-Dual licensed under the [MIT license][MIT] and [GPL license][GPL].
-
-[MIT]: http://www.opensource.org/licenses/mit-license.php
-[GPL]: http://www.gnu.org/licenses/gpl.html
+Copyright (c) 2012-2019 miraoto
+The plugin is available as open source under the terms of the [MIT License](http://opensource.org/licenses/MIT).
 


### PR DESCRIPTION
From the request of https://github.com/miraoto/jquery.simpleTicker.js/issues/5, this plugin license change from MIT and GPL dual license to MIT license.